### PR TITLE
Improve alien clearing to reduce flicker

### DIFF
--- a/invaders.ino
+++ b/invaders.ino
@@ -198,8 +198,6 @@ void clearBullet() {
 // }
 
 void updateAliens() {
-  // Clear the entire area where aliens live
-  M5Cardputer.Display.fillRect(0, alienAreaTop, SCREEN_W, alienAreaHeight, BLACK);
 
   for (int row = 0; row < numRows; row++) {
     for (int col = 0; col < numCols; col++) {
@@ -229,11 +227,13 @@ bool isExplosionAt(int x, int y) {
 }
 
 void clearAliens() {
+  const int spriteSize = 8;  // actual drawn alien sprite dimension
   for (int row = 0; row < numRows; row++) {
     for (int col = 0; col < numCols; col++) {
       Alien &a = aliens[row][col];
-      if (a.alive && !isExplosionAt(a.x, a.y)) {
-        M5Cardputer.Display.fillRect(a.x, a.y, alienW, alienH, BLACK);
+      if (!isExplosionAt(a.x, a.y)) {
+        // Clear both living and recently destroyed aliens
+        M5Cardputer.Display.fillRect(a.x, a.y, spriteSize, spriteSize, BLACK);
       }
     }
   }
@@ -1008,7 +1008,7 @@ void loop() {
     lastFrame = millis();
     clearShip();
     if (bulletActive) clearBullet();
-    // clearAliens();
+    clearAliens();
     clearExplosions();
     clearAlienBullets();
 


### PR DESCRIPTION
## Summary
- remove the global fillRect erase from `updateAliens`
- call `clearAliens()` each frame in `loop`
- ensure `clearAliens()` clears the full 8x8 sprite so aliens don't leave trails

## Testing
- `apt-get update`
- `apt-get install -y arduino-cli` *(fails: Unable to locate package)*
- attempted `curl` install of arduino-cli *(blocked: downloads.arduino.cc)*

------
https://chatgpt.com/codex/tasks/task_e_6870347f9aa88323af7ed3314d86df74